### PR TITLE
Fix typo in slide

### DIFF
--- a/introduction-to-go.slide
+++ b/introduction-to-go.slide
@@ -21,7 +21,7 @@ The materials for this presentation are available on GitHub:
 
 You are encouraged to remix, transform, or build upon the material, providing you give appropriate credit and distribute your contributions under the same license.
 
-If you have suggestions or corrections to this presentation, please raise [[https://github.com/davecheney/introduction-to-go/isues][an issue on the GitHub project]].
+If you have suggestions or corrections to this presentation, please raise [[https://github.com/davecheney/introduction-to-go/issues][an issue on the GitHub project]].
 
 * Agenda
 


### PR DESCRIPTION
Not correct url.

#### Before
```
https://github.com/davecheney/introduction-to-go/isues
```

#### After
```
https://github.com/davecheney/introduction-to-go/issues
```


Thank you for today !